### PR TITLE
Use temporary_assigns for requests

### DIFF
--- a/lib/lasso_web/live/lasso_liveview.ex
+++ b/lib/lasso_web/live/lasso_liveview.ex
@@ -16,19 +16,20 @@ defmodule LassoWeb.LassoLiveView do
     assigns = [
       requests: Map.fetch!(session, "requests"),
       url: Map.fetch!(session, "url"),
-      uuid: uuid
+      uuid: uuid,
+      cleared: false
     ]
 
-    {:ok, assign(socket, assigns)}
+    {:ok, assign(socket, assigns), temporary_assigns: [requests: []]}
   end
 
   def handle_info({Lasso, _uuid, {:request, request}}, socket) do
     all_requests = Enum.take([request | socket.assigns.requests], @request_limit)
-    {:noreply, assign(socket, :requests, all_requests)}
+    {:noreply, assign(socket, requests: all_requests, cleared: false)}
   end
 
   def handle_info({Lasso, _uuid, :clear}, socket) do
-    {:noreply, assign(socket, :requests, [])}
+    {:noreply, assign(socket, requests: [], cleared: true)}
   end
 
   def handle_info({Lasso, _uuid, :delete}, socket) do
@@ -38,7 +39,7 @@ defmodule LassoWeb.LassoLiveView do
   def handle_event("clear", _, %{assigns: %{uuid: uuid}} = socket) do
     Logger.info("Clearing requests for lasso with uuid: #{uuid}")
     socket = clear(socket, uuid)
-    {:noreply, assign(socket, :requests, [])}
+    {:noreply, assign(socket, requests: [], cleared: true)}
   end
 
   def handle_event("delete", _, %{assigns: %{uuid: uuid}} = socket) do

--- a/lib/lasso_web/templates/lasso_view/lasso.html.leex
+++ b/lib/lasso_web/templates/lasso_view/lasso.html.leex
@@ -34,9 +34,5 @@
 </div>
 
 <div class="row justify-content-center">
-<div class="col-12" id="requests">
-    <%= for request <- @requests do %>
-        <%= render "request.html", request: request %>
-    <% end %>
-</div>
+    <%= render_requests(@requests, cleared?: @cleared) %>
 </div>

--- a/lib/lasso_web/templates/lasso_view/request.html.eex
+++ b/lib/lasso_web/templates/lasso_view/request.html.eex
@@ -1,5 +1,5 @@
 
-<div class="row">
+<div class="row" id="request-<%= DateTime.to_iso8601(@request.timestamp) %>">
 <div class="col">
 
 <div class="card mb-3" role="article" aria-label="Request details">

--- a/lib/lasso_web/views/lasso_view_view.ex
+++ b/lib/lasso_web/views/lasso_view_view.ex
@@ -1,3 +1,23 @@
 defmodule LassoWeb.LassoViewView do
   use LassoWeb, :view
+
+  @doc """
+  Render requests unless the lasso is cleared.
+
+  This is a bit of a hack, since requests are marked as temporary_assigns in the liveview
+  clearing the list won't force the DOM to actually remove all elements. This is why
+  there is a `cleared` flag.
+  """
+  def render_requests(_requests, cleared?: true) do
+    content_tag(:div, class: "col-12", id: "requests") do
+    end
+  end
+
+  def render_requests(requests, cleared?: false) do
+    content_tag(:div, class: "col-12", id: "requests", "phx-update": "prepend") do
+      for request <- requests do
+        render("request.html", request: request)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This should make the lasso live view require less memory
since all requests will not be kept in memory.