### PR TITLE
Replace Application.get_env use with compile_env

### DIFF
--- a/lib/lasso.ex
+++ b/lib/lasso.ex
@@ -4,8 +4,8 @@ defmodule Lasso do
   """
   require Logger
 
-  @cache_id Application.get_env(:lasso, Lasso)[:cache_name]
-  @request_limit Application.get_env(:lasso, Lasso)[:max_requests_per_lasso]
+  @cache_id Application.compile_env(:lasso, [Lasso, :cache_name])
+  @request_limit Application.compile_env(:lasso, [Lasso, :max_requests_per_lasso])
 
   @topic inspect(__MODULE__)
 

--- a/lib/lasso/application.ex
+++ b/lib/lasso/application.ex
@@ -3,11 +3,13 @@ defmodule Lasso.Application do
 
   use Application
 
+  @cache_name Application.compile_env(:lasso, [Lasso, :cache_name])
+
   def start(_type, _args) do
     children = [
       {ConCache,
        [
-         name: Application.get_env(:lasso, Lasso)[:cache_name],
+         name: @cache_name,
          ttl_check_interval: :timer.minutes(10),
          global_ttl: :timer.hours(24),
          ets_options: [:compressed],

--- a/lib/lasso_web/live/admin_liveview.ex
+++ b/lib/lasso_web/live/admin_liveview.ex
@@ -3,7 +3,7 @@ defmodule LassoWeb.AdminLiveView do
 
   require Logger
 
-  @admin_events Application.get_env(:lasso, Lasso)[:admin_events_topic]
+  @admin_events Application.compile_env(:lasso, [Lasso, :admin_events_topic])
 
   def render(assigns) do
     LassoWeb.AdminView.render("index.html", assigns)

--- a/lib/lasso_web/live/lasso_liveview.ex
+++ b/lib/lasso_web/live/lasso_liveview.ex
@@ -3,7 +3,7 @@ defmodule LassoWeb.LassoLiveView do
 
   require Logger
 
-  @request_limit Application.get_env(:lasso, Lasso)[:max_requests_per_lasso]
+  @request_limit Application.compile_env(:lasso, [Lasso, :max_requests_per_lasso])
 
   def render(assigns) do
     LassoWeb.LassoViewView.render("lasso.html", assigns)


### PR DESCRIPTION
`compile_env` is more explicit and won't trigger
the `ApplicationConfigInModuleAttribute` credo warning.

https://hexdocs.pm/credo/Credo.Check.Warning.ApplicationConfigInModuleAttribute.html